### PR TITLE
Improve popup instructions and add status

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -17,9 +17,12 @@
 </head>
 <body>
   <h2>ChatGPT Auto Sender by Anderson Mak</h2>
-  Mais Hacks no meu Canal: <a href="https://www.youtube.com/@AndersonMak" target="_blank">https://www.youtube.com/@AndersonMak</a>
-  <!-- Caixa de texto onde o usuário insere os prompts, separados por linha -->
-  <textarea id="prompts" rows="5" placeholder="Enter prompts, one per line"></textarea>
+  <p id="instructions">Enter one prompt per line then click <strong>Start Sending</strong>.</p>
+  <textarea id="prompts" rows="5" placeholder="Type a prompt on each line"></textarea>
+  <p id="status">Status: Idle</p>
+  <div style="font-size: smaller;">
+    <a href="https://www.youtube.com/@AndersonMak" target="_blank">Mais Hacks no meu Canal</a>
+  </div>
   <button id="start">Start Sending</button>
   <button id="stop">Stop Sending</button>
 

--- a/popup.js
+++ b/popup.js
@@ -1,4 +1,7 @@
 document.addEventListener('DOMContentLoaded', () => {
+  const statusEl = document.getElementById("status");
+  statusEl.textContent = "Status: Idle";
+
   // Restaurar os prompts salvos quando o popup for aberto
   chrome.storage.local.get("prompts", (data) => {
     if (data.prompts) {
@@ -15,6 +18,7 @@ document.addEventListener('DOMContentLoaded', () => {
       chrome.storage.local.set({ prompts: rawPrompts });
 
       chrome.runtime.sendMessage({ action: "start", prompts });  // Enviar os prompts como um array de linhas
+      statusEl.textContent = "Sending prompts...";
     } else {
       alert("Please enter at least one valid prompt.");
     }
@@ -22,5 +26,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
   document.getElementById("stop").addEventListener("click", () => {
     chrome.runtime.sendMessage({ action: "stop" });  // Enviar mensagem para parar o envio dos prompts
+    statusEl.textContent = "Stopped.";
   });
 });


### PR DESCRIPTION
## Summary
- clarify how to use the extension in the popup
- show current status while prompts are running
- move YouTube link to a small footer

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68754f35d91883338f4a300d2438031b