### PR TITLE
Support chatgpt.com domain

### DIFF
--- a/background.js
+++ b/background.js
@@ -138,7 +138,7 @@ function sendPromptToChatGPT(prompt) {
 
       const activeTab = tabs[0];
       const url = activeTab.url || "";
-      const chatGPTRegex = /^https:\/\/chat\.openai\.com/;
+      const chatGPTRegex = /^https:\/\/(chat\.openai\.com|chatgpt\.com)/;
 
       if (!chatGPTRegex.test(url)) {
         const msg = "Por favor, abra o ChatGPT na aba ativa.";


### PR DESCRIPTION
## Summary
- Allow the extension to work on both chat.openai.com and chatgpt.com by updating the domain validation regex.

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `node -e "const regex=/^https:\/\/(chat\.openai\.com|chatgpt\.com)/; console.log(regex.test('https://chat.openai.com'), regex.test('https://chatgpt.com'), regex.test('https://example.com'));"`

------
https://chatgpt.com/codex/tasks/task_e_689685bda69483338e85822bece61a97